### PR TITLE
New Locking Method

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -31,3 +31,12 @@ RegisterNetEvent('bcc-doorlocks:ClientSetDoorStatus', function(doorTable, locked
         lockAndUnlockDoorHandler(doorTable)
     end
 end)
+
+CreateThread(function()
+    if Config.DevMode then
+        RegisterCommand('devboy', function()
+            TriggerServerEvent('bcc-doorlocks:InitLoadDoorLocks')
+            TriggerServerEvent('bcc-doorlocks:AdminCheck')
+        end)
+    end
+end)

--- a/client/functions.lua
+++ b/client/functions.lua
@@ -16,34 +16,59 @@ function getDoor(type) --Funct to unlock door
   elseif type == 'deletion' then
     VORPcore.NotifyRightTip(_U("deleteDoorInstructions"), 4000)
   end
+  VORPcore.NotifyRightTip(_U("doorNotShow"), 4000)
+
+  local type2 = false
   while true do
     Wait(5)
     local id = PlayerId()
-    if IsPlayerFreeAiming(id) then
-      local bool, entity = GetEntityPlayerIsFreeAimingAt(id)
-      if bool then
-        local model = GetEntityModel(entity)
-        if model ~= nil and model ~= 0 then
-          for k, v in pairs(Doorhashes) do
-            if v[2] == model then
-              table.insert(modelAimedAt, v)
+    if not type2 then
+      if IsControlJustReleased(0, 0xCEFD9220) then type2 = true end
+      if IsPlayerFreeAiming(id) then
+        local bool, entity = GetEntityPlayerIsFreeAimingAt(id)
+        if bool then
+          local model = GetEntityModel(entity)
+          if model ~= nil and model ~= 0 then
+            for k, v in pairs(Doorhashes) do
+              if v[2] == model then
+                table.insert(modelAimedAt, v)
+              end
             end
-          end
 
-          for k, v in pairs(modelAimedAt) do
-            local aimedEntityCoords = GetEntityCoords(entity)
-            if GetDistanceBetweenCoords(v[4], v[5], v[6], aimedEntityCoords.x, aimedEntityCoords.y, aimedEntityCoords.z, true) < 1 then
-              door = v break
+            for k, v in pairs(modelAimedAt) do
+              local aimedEntityCoords = GetEntityCoords(entity)
+              if GetDistanceBetweenCoords(v[4], v[5], v[6], aimedEntityCoords.x, aimedEntityCoords.y, aimedEntityCoords.z, true) < 1 then
+                door = v break
+              end
+            end
+            if door ~= nil then
+              if type == 'creation' then
+                BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionLocking"))
+              elseif type == 'deletion' then
+                BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionDeletion"))
+              end
+              if IsControlJustReleased(0, 0x760A9C6F) then break end
             end
           end
-          if door ~= nil then
-            if type == 'creation' then
-              BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionLocking"))
-            elseif type == 'deletion' then
-              BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionDeletion"))
-            end
-            if IsControlJustReleased(0, 0x760A9C6F) then break end
+        end
+      end
+    else
+      local plc = GetEntityCoords(PlayerPedId())
+      for k, v in pairs(Doorhashes) do
+        if GetDistanceBetweenCoords(plc.x, plc.y, plc.z, v[4], v[5], v[6], true) < 1.5 then
+          door = v break
+        end
+      end
+      if door ~= nil then
+        if GetDistanceBetweenCoords(plc.x, plc.y, plc.z, door[4], door[5], door[6], true) < 1.5 then
+          if type == 'creation' then
+            BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionLocking"))
+          elseif type == 'deletion' then
+            BccUtils.Misc.DrawText3D(door[4], door[5], door[6] + 1, _U("questionDeletion"))
           end
+          if IsControlJustReleased(0, 0x760A9C6F) then break end
+        else
+          door = nil
         end
       end
     end

--- a/config.lua
+++ b/config.lua
@@ -1,15 +1,16 @@
 Config = {}
 
 Config.defaultlang = 'en_lang'
+Config.DevMode = false
 
 ---------- Admin Configuration (Anyone listed here will be able to create and delete doors!) -----------
 Config.AdminSteamIds = {
     {
-        steamid = 'steam:11000013707db22', --insert players steam id
+        steamid = 'steam:11000013707db23', --insert players steam id
     }, --to add more just copy this table paste and change id
     {
-        steamid = 'id2'
-    }
+        steamid = 'steam:11000013707db22', --insert players steam id
+    }, --to add more just copy this table paste and change id
 }
 
 Config.LockPicking = {

--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -6,8 +6,9 @@ Locales["en_lang"] = {
     doorExists = 'Door already has been locked',
     createDoorInstructions = 'Aim at the door you wish to lock, and press "G" while aiming at it too lock the door!',
     deleteDoorInstructions = 'Aim at the door you wish to delete, and press "G" while aiming at it too delete the door!',
-    questionLocking = 'Lock this door?',
-    questionDeletion = 'Delete this door lock?',
+    doorNotShow = 'If the door you are aiming at is not showing up press "e" and stand beside it!',
+    questionLocking = 'Lock this door Press "G"?',
+    questionDeletion = 'Delete this door lock Press "G"?',
     doorDeleted = 'Door deleted!',
 
     ----Non admin text ----

--- a/server/server.lua
+++ b/server/server.lua
@@ -7,7 +7,13 @@ BccUtils = exports['bcc-utils'].initiate()
 
 ------ DataBase Handling ------
 RegisterServerEvent('bcc-doorlocks:InsertIntoDB', function(doorTable, jobs, keyItem) --Handles door creation and locks the door for all clients upon creation
-  local param = { ['jobs'] = json.encode(jobs), ['key'] = keyItem, ['locked'] = 'true', ['doorinfo'] = json.encode(doorTable) }
+  local kItem
+  if keyItem ~= nil then
+    kItem = keyItem
+  else
+    kItem = 'none'
+  end
+  local param = { ['jobs'] = json.encode(jobs), ['key'] = kItem, ['locked'] = 'true', ['doorinfo'] = json.encode(doorTable) }
   local _source = source
 
   exports.oxmysql:execute("SELECT * FROM doorlocks WHERE doorinfo=@doorinfo", param, function(result)


### PR DESCRIPTION
- Fix sql error when you do not set a key item
- dev mode option in config for development
- New locking method! This is used mainly for doors that do not show up when aiming at them! You can press "E" and stand beside the door then when you see the text press "G" to lock it.