### PR TITLE
Create Door Updated

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -52,6 +52,7 @@ exports('createDoor', function()
     while not ExportDoorCreationFinished do
         Wait(100)
     end
+    ExportDoorCreationFinished = false
     return ExportDoorCreationId
 end)
 

--- a/client/client.lua
+++ b/client/client.lua
@@ -45,10 +45,14 @@ CreateThread(function()
 end)
 
 ----- Exports -------
+ExportDoorCreationId, ExportDoorCreationFinished = nil, false
 exports('createDoor', function()
     local door = getDoor('creation')
     doorCreationMenu(door)
-    return door
+    while not ExportDoorCreationFinished do
+        Wait(100)
+    end
+    return ExportDoorCreationId
 end)
 
 exports('deleteDoor', function()
@@ -62,4 +66,9 @@ exports('deleteSpecificDoor', function(doorTable)
             TriggerServerEvent('bcc-doorlocks:DeleteDoor', v) break
         end
     end
+end)
+
+RegisterNetEvent('bcc-doorlocks:ExportCreationIdCatch', function(doorid)
+    ExportDoorCreationId = doorid
+    ExportDoorCreationFinished = true
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -30,6 +30,11 @@ RegisterServerEvent('bcc-doorlocks:InsertIntoDB', function(doorTable, jobs, keyI
       VORPcore.NotifyRightTip(_source, _U("doorExists"), 4000)
     end
   end)
+
+  local result = MySQL.query.await("SELECT * FROM doorlocks WHERE doorinfo=@doorinfo", param)
+  if #result >= 1 then
+    TriggerClientEvent('bcc-doorlocks:ExportCreationIdCatch', _source, result[1].doorid)
+  end
 end)
 
 RegisterServerEvent('bcc-doorlocks:AdminCheck', function() --admin checking against config settings


### PR DESCRIPTION
While working on a new project I discovered the create door export returned door table can not be used to select the door from doorlocks db table from another script. To fix this the create door export now returns the door id from doorlocks table to make choosing the door from the db table simple