### PR TITLE
export-fix

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -29,12 +29,11 @@ RegisterServerEvent('bcc-doorlocks:InsertIntoDB', function(doorTable, jobs, keyI
     else
       VORPcore.NotifyRightTip(_source, _U("doorExists"), 4000)
     end
+    local result2 = MySQL.query.await("SELECT * FROM doorlocks WHERE doorinfo=@doorinfo", param)
+    if #result2 >= 1 then
+      TriggerClientEvent('bcc-doorlocks:ExportCreationIdCatch', _source, result2[1].doorid)
+    end
   end)
-
-  local result = MySQL.query.await("SELECT * FROM doorlocks WHERE doorinfo=@doorinfo", param)
-  if #result >= 1 then
-    TriggerClientEvent('bcc-doorlocks:ExportCreationIdCatch', _source, result[1].doorid)
-  end
 end)
 
 RegisterServerEvent('bcc-doorlocks:AdminCheck', function() --admin checking against config settings


### PR DESCRIPTION
Moved the return handler inside the previous oxmysql query as it was running the event before the query was ran causing errors. This makes the return event trigger only after the query is done